### PR TITLE
패키지 네임 중복 수정

### DIFF
--- a/.changeset/chatty-files-listen.md
+++ b/.changeset/chatty-files-listen.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+패키지 네임 중복 수정

--- a/.changeset/dull-crabs-type.md
+++ b/.changeset/dull-crabs-type.md
@@ -2,5 +2,5 @@
 "@ndive/react-image": patch
 ---
 
-chore: release 
+chore: release
 패키지 종속성 업데이트 및 CI 수정

--- a/.changeset/huge-webs-retire.md
+++ b/.changeset/huge-webs-retire.md
@@ -1,0 +1,5 @@
+---
+'@jinseun-packages/react-image': patch
+---
+
+패키지 네임 중복으로 인해 수정

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
     "@schema": "https://json.schemastore.org/package",
-    "name": "@ndive/react-image",
-    "version": "0.1.0",
+    "name": "@jinseun-packages/react-image",
+    "publishConfig": {
+        "access": "public"
+    },
+    "version": "0.1.1",
     "description": "A comprehensive image utility kit for Next.js, and React. this package is created for leaning purposes. Caution is advised when using in production.",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",


### PR DESCRIPTION
패키지 네임 중복으로 npm에 릴리즈 되지않아 
'@jinseun-package/react-image'로 수정